### PR TITLE
Fixes input string

### DIFF
--- a/scripts/word_cloud.py
+++ b/scripts/word_cloud.py
@@ -7,10 +7,11 @@ df = pd.read_csv("../vivek_1000_post_sentiment_gathering.csv")
 
 # Wordcloud with positive tweets
 positive_tweets = df["Tweet"][df["Sentiment"] == "Positive"]
+positive_tweets = " ".join(positive_tweets.values)
 stop_words = ["https", "co", "RT"] + list(STOPWORDS)
 positive_wordcloud = WordCloud(
     max_font_size=50, max_words=50, background_color="white", stopwords=stop_words
-).generate(str(positive_tweets))
+).generate(positive_tweets)
 plt.figure()
 plt.title("Positive Tweets - Wordcloud")
 plt.imshow(positive_wordcloud, interpolation="bilinear")
@@ -20,10 +21,11 @@ plt.show()
 
 # Wordcloud with negative tweets
 negative_tweets = df["Tweet"][df["Sentiment"] == "Negative"]
+negative_tweets = " ".join(negative_tweets.values)
 stop_words = ["https", "co", "RT"] + list(STOPWORDS)
 negative_wordcloud = WordCloud(
     max_font_size=50, max_words=50, background_color="white", stopwords=stop_words
-).generate(str(negative_tweets))
+).generate(negative_tweets)
 plt.figure()
 plt.title("Negative Tweets - Wordcloud")
 plt.imshow(negative_wordcloud, interpolation="bilinear")


### PR DESCRIPTION
To fix `AttributeError: 'ImageDraw' object has no attribute 'textsize' ` use pillow==9.5.0 as higher versions have deprecated methods. Tested it locally with the current changes & pillow==9.5.0 (on python3.9) and worked.

Also added few minor fixes.